### PR TITLE
Simplify git push command in gig-updater workflow

### DIFF
--- a/.github/workflows/gig-updater.yml
+++ b/.github/workflows/gig-updater.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Commit and push changes to main branch
         if: steps.check_expired.outputs.found_expired == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add data/gigs.json data/archive.json
           git commit -m "Remove expired gigs from gigs.json and archive them" || echo "No changes to commit"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          git push


### PR DESCRIPTION
Updated the push command to use the default GITHUB_TOKEN.